### PR TITLE
GTFS-realtime trip updates prediction accuracy module.

### DIFF
--- a/transitime/src/main/java/org/transitime/core/predAccuracy/PredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/PredictionAccuracyModule.java
@@ -331,10 +331,13 @@ public class PredictionAccuracyModule extends Module {
 					// a bad prediction was made
 					storePredictionAccuracyInfo(pred, null);
 				} else {
-					++numPredictionsInMemory;					
+					++numPredictionsInMemory;		
+					logger.debug("Prediction currently held in memory. {}"+pred.toString());
 				}
 			}
 		}
+		
+		
 		
 		logger.debug("There are now {} predictions in memory after removing {}.",
 				numPredictionsInMemory, numPredictionsRemoved);

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/PredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/PredictionAccuracyModule.java
@@ -419,8 +419,12 @@ public class PredictionAccuracyModule extends Module {
 		PredictionKey key = new PredictionKey(arrivalDeparture.getVehicleId(), 
 				arrivalDeparture.getDirectionId(), arrivalDeparture.getStopId());
 		List<PredAccuracyPrediction> predsList = predictionMap.get(key);
+		
 		if (predsList == null || predsList.isEmpty())
-			return;
+		{
+			logger.debug("No matching predictions for {}", arrivalDeparture);
+			return;			
+		}
 		
 		// Go through list of predictions for vehicle, direction, stop and handle
 		// the ones that match fully including being appropriate arrival or

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -138,7 +138,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 						 	String direction=null;
 						 	if(update.getTrip().hasDirectionId())
 						 		direction=""+update.getTrip().getDirectionId();
-						 	
+						 							 							 
 						 	PredAccuracyPrediction pred = new PredAccuracyPrediction(
 							update.getTrip().getRouteId(), 
 							direction, 
@@ -146,7 +146,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 							update.getTrip().getTripId(), 
 							update.getVehicle().getId(),							
 							new Date(stopTime.getArrival().getTime()*1000) , 
-							new Date(update.getTimestamp()*1000), 
+							new Date(feed.getHeader().getTimestamp()*1000),													
 							true,
 							new Boolean(false), 
 							"GTFS-rt");
@@ -154,7 +154,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 					 		storePrediction(pred);
 					 }else
 					 {
-						 logger.debug("NO arrival for vechicleId={} information at stop={}",update.getVehicle().getId(),stopTime.getStopId());
+						 logger.debug("No arrival for vechicleId={} information at stop={}",update.getVehicle().getId(),stopTime.getStopId());
 					 }
 				 }
 		     }

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -1,0 +1,198 @@
+/*
+ * This file is part of Transitime.org
+ * 
+ * Transitime.org is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL) as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Transitime.org is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Transitime.org .  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transitime.core.predAccuracy.gtfsrt;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.transitime.applications.Core;
+import org.transitime.config.StringConfigValue;
+import org.transitime.core.predAccuracy.PredAccuracyPrediction;
+import org.transitime.core.predAccuracy.PredictionAccuracyModule;
+import org.transitime.modules.Module;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
+
+/**
+ * Reads in external prediction data from a GTFS realtime trip updates feed and stores the data in
+ * memory. Then when arrivals/departures occur the prediction accuracy can be
+ * determined and stored.
+ *
+ * @author Sean Og Crudden
+ *
+ */
+public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModule {
+
+	// For when requesting predictions from external GTFS RT URL
+	private static final int timeoutMsec = 20000;
+	
+	private static final Logger logger = LoggerFactory
+			.getLogger(GTFSRealtimePredictionAccuracyModule.class);
+
+	/********************** Config Params **************************/
+	
+	private static final StringConfigValue gtfsTripUpdateUrl = 
+			new StringConfigValue("transitime.predAccuracy.gtfsTripUpdateUrl", 
+					"http://127.0.0.1:8091/trip-updates",
+					"URL to access gtfs-rt trip updates.");
+		
+	
+	/**
+	 * @return the gtfstripupdateurl
+	 */
+	public static StringConfigValue getGtfstripupdateurl() {
+		return gtfsTripUpdateUrl;
+	}
+
+	
+	
+	/********************** Member Functions **************************/
+
+	/**
+	 * @param agencyId
+	 */
+	public GTFSRealtimePredictionAccuracyModule(String agencyId) {
+		super(agencyId);
+	}
+
+	
+	
+	/**
+	 * Gets GTFS realtime feed all routes from URL and return FeedMessage
+	 * 
+	 * @return the FeedMessage to be processed
+	 */
+	private FeedMessage getExternalPredictions() {
+				
+		// Will just read all data from gtfs-rt url
+		URL url=null;
+		logger.info("Getting predictions from API using URL={}", getGtfstripupdateurl().getValue());
+		
+		try {
+			// Create the connection
+			url = new URL(getGtfstripupdateurl().getValue());
+			
+			FeedMessage feed = FeedMessage.parseFrom(url.openStream());			   
+									
+			return feed;
+		} catch (Exception e) {
+			logger.error("Problem when getting data from GTFS realtime trip updates URL={}", 
+					url, e);
+			return null;
+		}
+	}
+	
+	/**
+	 * Takes data from XML Document object and processes it and
+	 * calls storePrediction() on the predictions.
+	 * 
+	 * @param feed
+	 * @param predictionsReadTime
+	 */
+	private void processExternalPredictions(
+			FeedMessage feed,
+			Date predictionsReadTime) {
+
+		// If couldn't read data from feed then can't process it		
+		if (feed == null)		
+			return;
+		
+		 for (FeedEntity entity : feed.getEntityList()) 
+		 {
+			 if (entity.hasTripUpdate()) 
+			 {
+				 TripUpdate update = entity.getTripUpdate();
+				 List<StopTimeUpdate> stopTimes = update.getStopTimeUpdateList();
+				 for(StopTimeUpdate stopTime : stopTimes)
+				 {					 
+					 if(stopTime.hasArrival())
+					 {						 
+						 	logger.debug("Storing external prediction routeId={}, "
+									+ "directionId={}, tripId={}, vehicleId={}, "
+									+ "stopId={}, prediction={}, isArrival={}",
+									update.getTrip().getRouteId(), new String(""+update.getTrip().getDirectionId()), update.getTrip().getTripId(), update.getVehicle().getId(), stopTime.getStopId(),
+									new Date(stopTime.getArrival().getTime()), true);
+						 	
+						    // Store in memory the prediction based on absolute time
+						 	PredAccuracyPrediction pred = new PredAccuracyPrediction(
+							update.getTrip().getRouteId(), 
+							new String(""+update.getTrip().getDirectionId()), 
+							stopTime.getStopId(), 
+							update.getTrip().getTripId(), 
+							update.getVehicle().getId(),
+							new Date(stopTime.getArrival().getTime()) , 
+							new Date(update.getTimestamp()), 
+							true,
+							new Boolean(false), 
+							"GTFS-RT");
+					 
+					 		storePrediction(pred);
+					 }									 					
+				 }
+		     }
+		 }
+		
+	
+	}
+	
+	/**
+	 * Processes both the internal and external predictions
+	 * 
+	 * @param routesAndStops
+	 * @param predictionsReadTime
+	 *            For keeping track of when the predictions read in. Used for
+	 *            determining length of predictions. Should be the same for all
+	 *            predictions read in during a polling cycle even if the
+	 *            predictions are read at slightly different times. By using the
+	 *            same time can easily see from data in db which internal and
+	 *            external predictions are associated with each other.
+	 */
+	@Override
+	protected void getAndProcessData(List<RouteAndStops> routesAndStops, 
+			Date predictionsReadTime) {
+		// Process internal predictions
+		super.getAndProcessData(routesAndStops, predictionsReadTime);
+		
+		logger.debug("Calling GTFSRealtimePredictionAccuracyModule."
+				+ "getAndProcessData()");
+		
+		// Get data for all items in the GTFS-RT trip updates feed		
+		FeedMessage feed = getExternalPredictions();
+			
+		processExternalPredictions(feed, predictionsReadTime);
+		
+	}
+
+	/**
+	 * Just for debugging
+	 */
+	public static void main(String[] args) {
+		// Need to start up Core so that can access route & stop info
+		Core.createCore();
+
+		// Create a GTFSRealtimePredictionAccuracyModule for testing
+		Module.start("org.transitime.core.predAccuracy.gtfsrt.GTFSRealtimePredictionAccuracyModule");
+	}
+
+}

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -128,7 +128,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 				 {					 
 					 if(stopTime.hasArrival())
 					 {						 
-						 	logger.debug("Storing external prediction routeId={}, "
+						 	logger.info("Storing external prediction routeId={}, "
 									+ "directionId={}, tripId={}, vehicleId={}, "
 									+ "stopId={}, prediction={}, isArrival={}",
 									update.getTrip().getRouteId(), new String(""+update.getTrip().getDirectionId()), update.getTrip().getTripId(), update.getVehicle().getId(), stopTime.getStopId(),
@@ -144,7 +144,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 							direction, 
 							stopTime.getStopId(), 
 							update.getTrip().getTripId(), 
-							update.getVehicle().getId(),
+							update.getVehicle().getId(),							
 							new Date(stopTime.getArrival().getTime()*1000) , 
 							new Date(update.getTimestamp()*1000), 
 							true,
@@ -178,7 +178,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 		// Process internal predictions
 		super.getAndProcessData(routesAndStops, predictionsReadTime);
 		
-		logger.debug("Calling GTFSRealtimePredictionAccuracyModule."
+		logger.info("Calling GTFSRealtimePredictionAccuracyModule."
 				+ "getAndProcessData()");
 		
 		// Get data for all items in the GTFS-RT trip updates feed		

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -135,17 +135,21 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 									new Date(stopTime.getArrival().getTime()), true);
 						 	
 						    // Store in memory the prediction based on absolute time
+						 	String direction=null;
+						 	if(update.getTrip().hasDirectionId())
+						 		direction=""+update.getTrip().getDirectionId();
+						 	
 						 	PredAccuracyPrediction pred = new PredAccuracyPrediction(
 							update.getTrip().getRouteId(), 
-							new String(""+update.getTrip().getDirectionId()), 
+							direction, 
 							stopTime.getStopId(), 
 							update.getTrip().getTripId(), 
 							update.getVehicle().getId(),
-							new Date(stopTime.getArrival().getTime()) , 
-							new Date(update.getTimestamp()), 
+							new Date(stopTime.getArrival().getTime()*1000) , 
+							new Date(update.getTimestamp()*1000), 
 							true,
 							new Boolean(false), 
-							"GTFS-RT");
+							"GTFS-rt");
 					 
 					 		storePrediction(pred);
 					 }									 					

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -94,7 +94,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 			url = new URL(getGtfstripupdateurl().getValue());
 			
 			FeedMessage feed = FeedMessage.parseFrom(url.openStream());			   
-									
+			logger.info("Prediction read successfully from URL={}",getGtfstripupdateurl().getValue());
 			return feed;
 		} catch (Exception e) {
 			logger.error("Problem when getting data from GTFS realtime trip updates URL={}", 
@@ -117,7 +117,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 		// If couldn't read data from feed then can't process it		
 		if (feed == null)		
 			return;
-		
+		logger.info("Processing GTFS-rt feed.....");
 		 for (FeedEntity entity : feed.getEntityList()) 
 		 {
 			 if (entity.hasTripUpdate()) 
@@ -152,7 +152,10 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 							"GTFS-rt");
 					 
 					 		storePrediction(pred);
-					 }									 					
+					 }else
+					 {
+						 logger.debug("NO arrival for vechicleId={} information at stop={}",update.getVehicle().getId(),stopTime.getStopId());
+					 }
 				 }
 		     }
 		 }

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -193,7 +193,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 					 }					
 					 else
 					 {
-						 logger.debug("No prediction for vehicleId={} information for stop={}",update.getVehicle().getId(),stopTime.getStopId());
+						 logger.debug("No predictions for vehicleId={} for stop={}",update.getVehicle().getId(),stopTime.getStopId());
 					 }
 				 }
 		     }

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -135,7 +135,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 									update.getTrip().getRouteId(), new String(""+update.getTrip().getDirectionId()), update.getTrip().getTripId(), update.getVehicle().getId(), stopTime.getStopId(),
 									new Date(stopTime.getArrival().getTime()*1000), true);
 						 	
-						 	logger.info("Prediction in milliseonds is {} and converted it{}",stopTime.getArrival().getTime()*1000,  new Date(stopTime.getArrival().getTime()*1000));
+						 	logger.info("Prediction in milliseonds is {} and converted is {}",stopTime.getArrival().getTime()*1000,  new Date(stopTime.getArrival().getTime()*1000));
 						 	
 						    // Store in memory the prediction based on absolute time						 							 	
 						 	String direction=null;
@@ -158,7 +158,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 					 		storePrediction(pred);
 					 }else
 					 {
-						 logger.debug("No arrival for vechicleId={} information at stop={}",update.getVehicle().getId(),stopTime.getStopId());
+						 logger.debug("No arrival information for vehicleId={} information at stop={}",update.getVehicle().getId(),stopTime.getStopId());
 					 }
 				 }
 		     }

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -117,6 +117,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 		// If couldn't read data from feed then can't process it		
 		if (feed == null)		
 			return;
+		
 		logger.info("Processing GTFS-rt feed.....");
 		 for (FeedEntity entity : feed.getEntityList()) 
 		 {
@@ -158,9 +159,7 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 					 }
 				 }
 		     }
-		 }
-		
-	
+		 }			
 	}
 	
 	/**

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -135,6 +135,8 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 									update.getTrip().getRouteId(), new String(""+update.getTrip().getDirectionId()), update.getTrip().getTripId(), update.getVehicle().getId(), stopTime.getStopId(),
 									new Date(stopTime.getArrival().getTime()*1000), true);
 						 	
+						 	logger.info("Prediction in milliseonds is {} and converted it{}",stopTime.getArrival().getTime()*1000,  new Date(stopTime.getArrival().getTime()*1000));
+						 	
 						    // Store in memory the prediction based on absolute time						 							 	
 						 	String direction=null;
 						 	if(update.getTrip().hasDirectionId())

--- a/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
+++ b/transitime/src/main/java/org/transitime/core/predAccuracy/gtfsrt/GTFSRealtimePredictionAccuracyModule.java
@@ -133,9 +133,9 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 									+ "directionId={}, tripId={}, vehicleId={}, "
 									+ "stopId={}, prediction={}, isArrival={}",
 									update.getTrip().getRouteId(), new String(""+update.getTrip().getDirectionId()), update.getTrip().getTripId(), update.getVehicle().getId(), stopTime.getStopId(),
-									new Date(stopTime.getArrival().getTime()), true);
+									new Date(stopTime.getArrival().getTime()*1000), true);
 						 	
-						    // Store in memory the prediction based on absolute time
+						    // Store in memory the prediction based on absolute time						 							 	
 						 	String direction=null;
 						 	if(update.getTrip().hasDirectionId())
 						 		direction=""+update.getTrip().getDirectionId();
@@ -145,7 +145,8 @@ public class GTFSRealtimePredictionAccuracyModule extends PredictionAccuracyModu
 							direction, 
 							stopTime.getStopId(), 
 							update.getTrip().getTripId(), 
-							update.getVehicle().getId(),							
+							update.getVehicle().getId(),	
+							
 							new Date(stopTime.getArrival().getTime()*1000) , 
 							new Date(feed.getHeader().getTimestamp()*1000),													
 							true,

--- a/transitime/src/main/java/org/transitime/feed/gtfsRt/GtfsRtVehiclePositionsReaderBase.java
+++ b/transitime/src/main/java/org/transitime/feed/gtfsRt/GtfsRtVehiclePositionsReaderBase.java
@@ -135,7 +135,7 @@ public abstract class GtfsRtVehiclePositionsReaderBase {
 			// and arrival times. But better than not having a time at all.
 			long gpsTime;
 			if (vehicle.hasTimestamp())
-				gpsTime = vehicle.getTimestamp()*1000;
+				gpsTime = vehicle.getTimestamp()*Time.MS_PER_SEC;
 			else
 				gpsTime = System.currentTimeMillis();
 			
@@ -164,7 +164,7 @@ public abstract class GtfsRtVehiclePositionsReaderBase {
             // AvlReport is expecting time in ms while the proto provides it in
 		    // seconds
 			AvlReport avlReport = new AvlReport(vehicleId, 
-					gpsTime * Time.MS_PER_SEC,
+					gpsTime,
 					MathUtils.round(lat, 5), MathUtils.round(lon, 5), speed,
 					heading,
 					"GTFS-rt",

--- a/transitime/src/main/java/org/transitime/feed/gtfsRt/GtfsRtVehiclePositionsReaderBase.java
+++ b/transitime/src/main/java/org/transitime/feed/gtfsRt/GtfsRtVehiclePositionsReaderBase.java
@@ -135,7 +135,7 @@ public abstract class GtfsRtVehiclePositionsReaderBase {
 			// and arrival times. But better than not having a time at all.
 			long gpsTime;
 			if (vehicle.hasTimestamp())
-				gpsTime = vehicle.getTimestamp();
+				gpsTime = vehicle.getTimestamp()*1000;
 			else
 				gpsTime = System.currentTimeMillis();
 			

--- a/transitime/src/main/resources/logback.xml
+++ b/transitime/src/main/resources/logback.xml
@@ -360,7 +360,7 @@
 -->
 
   <logger name="org.transitime.core.predAccuracy"
-          level="debug" additivity="false">
+          level="info" additivity="false">
     <appender-ref ref="PRED_ACCURACY" />
   </logger>
 

--- a/transitime/src/main/resources/logback.xml
+++ b/transitime/src/main/resources/logback.xml
@@ -360,7 +360,7 @@
 -->
 
   <logger name="org.transitime.core.predAccuracy"
-          level="info" additivity="false">
+          level="debug" additivity="false">
     <appender-ref ref="PRED_ACCURACY" />
   </logger>
 


### PR DESCRIPTION
This is a module which will store GTFS-realtime trip updates as predictions in transiTime so the quality of the predictions in the stop time updates can be quantified, and also to compare with the quality of predictions generated by transiTime itself.

The parameter <b>transitime.predAccuracy.gtfsTripUpdateUrl</b> should be set to the URL of the GTFS-realtime trip update feed. This value can be set in the transitTimeConfig.xml file or by using the -D java command line option.
