### PR TITLE
Don't swallow exceptions in GtfsFileProcessor.

### DIFF
--- a/transitime/src/main/java/org/transitime/applications/GtfsFileProcessor.java
+++ b/transitime/src/main/java/org/transitime/applications/GtfsFileProcessor.java
@@ -641,7 +641,7 @@ public class GtfsFileProcessor {
 		try {
 			processor.process();
 		} catch (Exception e) {
-			logger.error(e.getMessage());
+			logger.error("Exception while processing GTFS", e);
 		}
 
 		// Found that when running on AWS that program never terminates,


### PR DESCRIPTION
If an exception occurs in `GtfsFileProcessor`, the exception is not passed to log4j, only the message, which hinders diagnosis of the underlying issue, because the traceback is not printed.
